### PR TITLE
Add in PreserveKeysDottedDict

### DIFF
--- a/dotted_dict/__init__.py
+++ b/dotted_dict/__init__.py
@@ -8,17 +8,7 @@ class DottedDict(dict):
     Override for the dict object to allow referencing of keys as attributes, i.e. dict.key
     """
 
-    def __new__(cls, *args, **kwargs):
-        """
-        Due to the way pickling works in python 3, we need to make sure
-        the box config is created as early as possible.
-        """
-        obj = super(DottedDict, cls).__new__(cls, *args, **kwargs)
-        obj._config = _get_config(cls, kwargs)
-        return obj
-
     def __init__(self, *args, **kwargs):
-        self._config = _get_config(self.__class__, kwargs)
         for arg in args:
             if isinstance(arg, dict):
                 self._parse_input_(arg)
@@ -61,22 +51,14 @@ class DottedDict(dict):
 
     def __setitem__(self, key, value):
         try:
-            if self._config["auto_correct"] == True:
-                try:
-                    self._is_valid_identifier_(key)
-                except ValueError:
-                    if not keyword.iskeyword(key):
-                        key = self._make_safe_(key)
-                    else:
-                        raise ValueError('Key "{0}" is a reserved keyword.'.format(key))
-                super(DottedDict, self).__setitem__(key, value)
-                self.__dict__.update({key: value})
+            self._is_valid_identifier_(key)
+        except ValueError:
+            if not keyword.iskeyword(key):
+                key = self._make_safe_(key)
             else:
-                super(DottedDict, self).__setitem__(key, value)
-                self.__dict__.update({key: value})
-        except AttributeError:
-            super(DottedDict, self).__setitem__(key, value)
-            self.__dict__.update({key: value})
+                raise ValueError('Key "{0}" is a reserved keyword.'.format(key))
+        super(DottedDict, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
 
     def _is_valid_identifier_(self, identifier):
         """
@@ -157,8 +139,99 @@ class DottedDict(dict):
         return out
 
 
-def _get_config(cls, kwargs):
+class PreserveKeysDottedDict(dict):
     """
-    Process init args for DottedDict.
+    Overrides auto correction of key names to safe attr names.  Can result in errors when using
+    attr name resolution.
     """
-    return {"auto_correct": kwargs.pop("auto_correct", True)}
+
+    def __init__(self, *args, **kwargs):
+        for arg in args:
+            if isinstance(arg, dict):
+                self._parse_input_(arg)
+            elif isinstance(arg, list):
+                for k, v in arg:
+                    self.__setitem__(k, v)
+            elif hasattr(arg, "__iter__"):
+                for k, v in list(arg):
+                    self.__setitem__(k, v)
+
+        if kwargs:
+            self._parse_input_(kwargs)
+
+    def __delattr__(self, item):
+        self.__delitem__(item)
+
+    def __delitem__(self, key):
+        super(PreserveKeysDottedDict, self).__delitem__(key)
+        del self.__dict__[key]
+
+    def __getattr__(self, attr):
+        try:
+            return self.__dict__[attr]
+        # Do this to match python default behavior
+        except KeyError:
+            raise AttributeError(attr)
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __repr__(self):
+        """
+        Wrap the returned dict in DottedDict() on output.
+        """
+        return "{0}({1})".format(
+            type(self).__name__, super(PreserveKeysDottedDict, self).__repr__()
+        )
+
+    def __setattr__(self, key, value):
+        self.__setitem__(key, value)
+
+    def __setitem__(self, key, value):
+        if keyword.iskeyword(key):
+            raise ValueError('Key "{0}" is a reserved keyword.'.format(key))
+        super(PreserveKeysDottedDict, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
+
+    def _parse_input_(self, input_item):
+        """
+        Parse the input item if dict into the dotted_dict constructor.
+        """
+        for key, value in input_item.items():
+            if isinstance(value, dict):
+                value = PreserveKeysDottedDict(**{str(k): v for k, v in value.items()})
+            if isinstance(value, list):
+                _list = []
+                for item in value:
+                    if isinstance(item, dict):
+                        _list.append(PreserveKeysDottedDict(item))
+                    else:
+                        _list.append(item)
+                value = _list
+            self.__setitem__(key, value)
+
+    def copy(self):
+        """
+        Ensure copy object is DottedDict, not dict.
+        """
+        return type(self)(self)
+
+    def to_dict(self):
+        """
+        Recursive conversion back to dict.
+        """
+        out = dict(self)
+        for key, value in out.items():
+            if value is self:
+                out[key] = out
+            elif hasattr(value, "to_dict"):
+                out[key] = value.to_dict()
+            elif isinstance(value, list):
+                _list = []
+                for item in value:
+                    if hasattr(item, "to_dict"):
+                        _list.append(item.to_dict())
+                    else:
+                        _list.append(item)
+                out[key] = _list
+        return out

--- a/tests/test_dotteddict.py
+++ b/tests/test_dotteddict.py
@@ -1,11 +1,11 @@
 import unittest
 
-from dotted_dict import DottedDict
+from dotted_dict import DottedDict, PreserveKeysDottedDict
 
 
 class dotteddictTests(unittest.TestCase):
     """
-    Test cases for the ``dotteddict`` class.
+    Test cases for the ``DottedDict`` and ``PreserveKeysDottedDict`` classes.
     """
 
     def test_child_dictionary_types(self):
@@ -112,3 +112,115 @@ class dotteddictTests(unittest.TestCase):
         dotted = DottedDict(zip(data, data))
         self.assertEquals(dotted.a, "a")
         self.assertEquals(dotted["b"], "b")
+
+    # PreseveKeysDottedDict
+    def test_pkdd_child_dictionary_types(self):
+        dotted = PreserveKeysDottedDict({"x": {"y": {"z": 5}}})
+
+        self.assertEqual(type(dotted.x), PreserveKeysDottedDict)
+        self.assertEqual(type(dotted.x.y), PreserveKeysDottedDict)
+
+    def test_pkdd_child_dictionary_types_accessor(self):
+        dotted = PreserveKeysDottedDict({"x": {"y": {"z": 5}}})
+
+        self.assertEqual(type(dotted["x"]), PreserveKeysDottedDict)
+        self.assertEqual(type(dotted["x"]["y"]), PreserveKeysDottedDict)
+
+    def test_pkdd_children_equivalence(self):
+        dotted = PreserveKeysDottedDict({"x": {"y": {"z": 5}}})
+
+        self.assertTrue(dotted.x is dotted["x"])
+        self.assertTrue(dotted.x.y is dotted["x"]["y"])
+
+    def test_pkdd_construction_without_data(self):
+        dotted = PreserveKeysDottedDict()
+        self.assertTrue(isinstance(dotted, PreserveKeysDottedDict))
+
+    def test_pkdd_copy(self):
+        my_dict = PreserveKeysDottedDict({"my key two": {"b": "c", 1: 2}})
+        dotted = my_dict.copy()
+        self.assertEquals(my_dict, dotted)
+
+    def test_pkdd_delete(self):
+        dotted = PreserveKeysDottedDict({"foo": 1})
+        del dotted.foo
+
+        self.assertRaises(KeyError)
+
+    def test_pkdd_dotted_get(self):
+        value = "foo"
+        data = {"color": {"blue": value}}
+
+        dotted = PreserveKeysDottedDict(data)
+
+        self.assertEqual(dotted.get("color").get("blue"), value)
+
+    def test_pkdd_items_format_invocation(self):
+        items = [("x", 1), ("y", 2), ("z", 3)]
+        dotted = PreserveKeysDottedDict(items)
+
+        self.assertEquals(dotted.x, 1)
+        self.assertEquals(dotted.y, 2)
+        self.assertEquals(dotted.z, 3)
+
+    def test_pkdd_missing_attribute_error(self):
+        dotted = PreserveKeysDottedDict({"foo": None})
+
+        with self.assertRaises(AttributeError):
+            dotted.missing
+
+    def test_pkdd_none_value(self):
+        value = None
+        dotted = PreserveKeysDottedDict({"foo": value})
+        self.assertTrue(dotted.foo is value)
+
+    def test_pkdd_not_valid_identifier(self):
+        dotted = PreserveKeysDottedDict({"foo-bar": 1, ".foo": 1, "foo baz": 1, 1: 2})
+        self.assertTrue(dotted["foo-bar"], 1)
+        self.assertTrue(dotted[".foo"], 1)
+        self.assertTrue(dotted["foo baz"], 1)
+        self.assertTrue(dotted[1], 2)
+        # Reserved keyword
+        with self.assertRaises(ValueError):
+            PreserveKeysDottedDict({"lambda": 1})
+
+    def test_pkdd_repr(self):
+        dotted = PreserveKeysDottedDict({"foo-bar": 1, ".foo": 1, "foo baz": 1, 1: 2})
+        assert eval(repr(dotted)) == dotted
+
+    def test_pkdd_set_via_attrib(self):
+        value = 42
+        meaning = PreserveKeysDottedDict()
+        meaning.oflife = value
+
+        self.assertEqual(meaning["oflife"], value)
+
+    def test_pkdd_setting_and_accessing(self):
+        key = "x"
+        value = 5
+        dotted = PreserveKeysDottedDict({key: value})
+
+        self.assertEqual(dotted[key], value)
+        self.assertEqual(dotted.x, value)
+        self.assertEqual(dotted.x, dotted[key])
+
+    def test_pkdd_to_dict(self):
+        dotted = PreserveKeysDottedDict(
+            PreserveKeysDottedDict({"a": "b", "c": {"d": "e"}, "f": [{"g": "h"}, 1]})
+        )
+        my_dict = dotted.to_dict()
+        self.assertEquals(dotted, my_dict)
+        self.assertEqual(type(dotted), PreserveKeysDottedDict)
+        self.assertEqual(type(dotted.f[0]), PreserveKeysDottedDict)
+        self.assertEqual(type(my_dict), dict)
+        self.assertEqual(type(my_dict["f"][0]), dict)
+
+    def test_pkdd_via_zip(self):
+        data = ["a", "b"]
+        dotted = PreserveKeysDottedDict(zip(data, data))
+        self.assertEquals(dotted.a, "a")
+        self.assertEquals(dotted["b"], "b")
+
+    def test_preserve_keys(self):
+        dotted = PreserveKeysDottedDict({"foo-bar": 1, ".foo": 1, "foo baz": 1, 1: 2})
+        self.assertEquals(dotted["foo baz"], 1)


### PR DESCRIPTION
This class allows a dotteddict without the enforcement of safe key/attr names.